### PR TITLE
Fix file resolution for non-root folder projects

### DIFF
--- a/src/main/kotlin/com/duxtinto/intellij/plugin/github/codereviews/ide/acl/services/editor/IdeaEditorDriver.kt
+++ b/src/main/kotlin/com/duxtinto/intellij/plugin/github/codereviews/ide/acl/services/editor/IdeaEditorDriver.kt
@@ -3,6 +3,7 @@ package com.duxtinto.intellij.plugin.github.codereviews.ide.acl.services.editor
 import com.duxtinto.intellij.plugin.github.codereviews.domain.DomainContract
 import com.duxtinto.intellij.plugin.github.codereviews.ide.acl.entities.ProjectExt
 import com.duxtinto.intellij.plugin.github.codereviews.ide.acl.entities.editor.IdeaDocumentDriver
+import org.jetbrains.plugins.github.util.GithubUtil
 import javax.inject.Inject
 
 class IdeaEditorDriver
@@ -11,9 +12,14 @@ class IdeaEditorDriver
             private val project: ProjectExt)
     : DomainContract.EditorDriver {
     override fun openDocument(filePath: String): DomainContract.DocumentDriver {
+        val rootFolder = GithubUtil.getGitRepository(project, null)?.root
+            ?: throw error("Could not determine root folder of the project's git repository.")
+        val file = rootFolder.findFileByRelativePath(filePath)
+            ?: throw IllegalStateException("Could not find file at path $filePath (for git root: $rootFolder)")
+
         return IdeaDocumentDriver(
                 project,
-                project.baseDir.findFileByRelativePath(filePath)!!
+                file
         )
     }
 }

--- a/src/main/kotlin/com/duxtinto/intellij/plugin/github/codereviews/ide/acl/services/editor/IdeaEditorDriver.kt
+++ b/src/main/kotlin/com/duxtinto/intellij/plugin/github/codereviews/ide/acl/services/editor/IdeaEditorDriver.kt
@@ -13,9 +13,9 @@ class IdeaEditorDriver
     : DomainContract.EditorDriver {
     override fun openDocument(filePath: String): DomainContract.DocumentDriver {
         val rootFolder = GithubUtil.getGitRepository(project, null)?.root
-            ?: throw error("Could not determine root folder of the project's git repository.")
+            ?: error("Could not determine root folder of the project's git repository.")
         val file = rootFolder.findFileByRelativePath(filePath)
-            ?: throw IllegalStateException("Could not find file at path $filePath (for git root: $rootFolder)")
+            ?: error("Could not find file at path $filePath (for git root: $rootFolder)")
 
         return IdeaDocumentDriver(
                 project,


### PR DESCRIPTION
This PR fixes an issue in Android Studio/IntelliJ gradle projects that had their `project.rootDir` in a subdirectory of the git root. In this situation, resolution from relative file names on comments would fail, since the relative path was invalid. For example:

```
project (git root)
 |- my project (root project)
```

The fix uses the existing `GithubUtil#getGitRepository` to first retrieve the root directory of the git repository, and then uses this to resolve the correct full path of the commented file.